### PR TITLE
make pde and sirius specifier compulsary dependants #1308

### DIFF
--- a/regpot_desktop/installation/releng/org.eclipse.efbt.repository/category.xml
+++ b/regpot_desktop/installation/releng/org.eclipse.efbt.repository/category.xml
@@ -33,5 +33,11 @@
    <feature id="org.eclipse.efbt.regpot_desktop.csvconverter.feature">
       <category name="efbt"/>
    </feature>
+   <feature id="org.eclipse.pde">
+      <category name="efbt"/>
+   </feature>
+   <feature id="org.eclipse.sirius.specifier">
+      <category name="efbt"/>
+   </feature>
    <category-def name="efbt" label="Complete EFBT Repository"/>
 </site>


### PR DESCRIPTION
https://github.com/eclipse/efbt/issues/1308