### PR TITLE
make pde and sirius specifier compulsary dependants #1308

### DIFF
--- a/regpot_desktop/installation/releng/org.eclipse.efbt.repository/category.xml
+++ b/regpot_desktop/installation/releng/org.eclipse.efbt.repository/category.xml
@@ -39,5 +39,8 @@
    <feature id="org.eclipse.sirius.specifier">
       <category name="efbt"/>
    </feature>
+   <feature id="org.eclipse.egit">
+      <category name="efbt"/>
+   </feature>
    <category-def name="efbt" label="Complete EFBT Repository"/>
 </site>

--- a/regpot_desktop/installation/releng/org.eclipse.efbt.target/org.eclipse.efbt.target.target
+++ b/regpot_desktop/installation/releng/org.eclipse.efbt.target/org.eclipse.efbt.target.target
@@ -39,5 +39,9 @@
 			<repository location="https://download.eclipse.org/releases/2023-12"/>
 			<unit id="org.eclipse.sirius.specifier.feature.group" version="7.3.0.202311270829"/>
 		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/releases/2023-12"/>
+			<unit id="org.eclipse.egit.feature.group" version="6.8.0.202311291450-r"/>
+		</location>
 	</locations>
 </target>


### PR DESCRIPTION
https://github.com/eclipse/efbt/issues/1308