### PR TITLE
Potential fix for code scanning alert no. 131: Information exposure through an exception

### DIFF
--- a/birds_nest/pybirdai/views.py
+++ b/birds_nest/pybirdai/views.py
@@ -4728,7 +4728,7 @@ def automode_status(request):
         logger.error(f"Error getting automode status: {str(e)}")
         return JsonResponse({
             'success': False,
-            'error': f'Error getting status: {str(e)}'
+            'error': 'An internal error occurred while getting status.'
         })
 
 def prepare_dpm_data(request):


### PR DESCRIPTION
Potential fix for [https://github.com/eclipse-efbt/efbt/security/code-scanning/131](https://github.com/eclipse-efbt/efbt/security/code-scanning/131)

To fix the issue, the code should avoid echoing internal exception details in responses that are sent to the client. Instead, a generic error message should be provided to users, while full error details (including stack trace if needed) should be logged server-side for debugging. Specifically, in `automode_status`, replace the error response at line 4729 to use a generic message such as `"An internal error occurred while getting status."`, and keep the detailed error logging as is. No additional dependencies are required for this change, as standard library `logging` is already used.

Edit only lines involved in building the error response within the `except` block: change the value of the `"error"` field to a generic message, not derived from `e`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
