### PR TITLE
Potential fix for code scanning alert no. 114: SQL query built from user-controlled sources

### DIFF
--- a/birds_nest/pybirdai/utils/clone_mode/import_from_metadata_export.py
+++ b/birds_nest/pybirdai/utils/clone_mode/import_from_metadata_export.py
@@ -11,7 +11,8 @@ import itertools
 from datetime import datetime
 from pathlib import Path
 
-# Django setup for standalone testing
+# Allowed table name pattern: letters, digits, underscores only
+import re
 class DjangoSetup:
     @staticmethod
     def setup():
@@ -1212,6 +1213,8 @@ class CSVDataImporter:
             # SQLite can have table names with/without "pybirdai_" prefix
             if table_name not in allowed_tables:
                 raise Exception(f"Blocked potentially unsafe table_name: {table_name}")
+            if not self._is_safe_table_name(table_name):
+                raise Exception(f"Unsafe table name (violates allowed character rules): {table_name}")
             with connection.cursor() as cursor:
                 # Disable foreign key constraints for SQLite during clearing
                 if connection.vendor == 'sqlite':
@@ -1877,6 +1880,11 @@ class CSVDataImporter:
         logger.info(f"Completed ordered CSV strings import. Processed {len(results)} files")
         return results
 
+
+    def _is_safe_table_name(self, table_name):
+        """Return True if table_name contains only allowed characters and matches expected pattern."""
+        # Only letters, digits, and underscores permitted
+        return bool(re.fullmatch(r'[A-Za-z0-9_]+', table_name))
 
 def import_bird_data_from_csv_export(path_or_content, use_fast_import=False):
     """


### PR DESCRIPTION
Potential fix for [https://github.com/eclipse-efbt/efbt/security/code-scanning/114](https://github.com/eclipse-efbt/efbt/security/code-scanning/114)

The best way to fix this is to avoid embedding table names directly into raw SQL. However, most database connector libraries (Django ORM included) don't provide parameters for table names—parameters can only be used for values. Since all table names are checked against an internal whitelist of model-backed tables, we can further sanitize them before embedding. The recommended approach is to verify that the table name only contains allowed characters (letters, digits, and underscores), and that it matches a known model table exactly. This adds an additional defense-in-depth against edge-case or cleverly crafted table names.  

**How to fix:**  
- Add a validation function (e.g., `_is_safe_table_name`) to check allowed characters.
- Before using `table_name` in SQL, call this function, and only allow table names that pass both the model map check and the safe character check.
- Document this in the comments, so future maintainers know the rules.
- Optionally, use database introspection in Django to get a true list of valid model table names if paranoid.

**Files/lines to change:**  
- In `birds_nest/pybirdai/utils/clone_mode/import_from_metadata_export.py`, add a validation function above the SQL execution block.  
- Add the extra validation just before executing raw SQL with `table_name` on line 1221.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
