### PR TITLE
Potential fix for code scanning alert no. 113: SQL query built from user-controlled sources

### DIFF
--- a/birds_nest/pybirdai/utils/clone_mode/import_from_metadata_export.py
+++ b/birds_nest/pybirdai/utils/clone_mode/import_from_metadata_export.py
@@ -618,7 +618,10 @@ class CSVDataImporter:
         Auto-generates sequential indices for models using Django's auto-generated primary keys.
         """
         logger.info(f"Starting bulk SQLite3 import for {table_name}")
-        
+        # Validate table name strictly before any SQL execution
+        if not self._is_safe_table_name(table_name) or table_name not in self.model_map:
+            logger.error(f"Unsafe or unknown table name detected: {table_name}")
+            raise Exception(f"Unsafe or unknown table name detected: {table_name}")
         # Parse CSV content
         headers, rows = self._parse_csv_content(csv_content)
         
@@ -713,6 +716,10 @@ class CSVDataImporter:
             
             # Verify import success
             with connection.cursor() as cursor:
+                # Validate table name right before executing SQL
+                if not self._is_safe_table_name(table_name) or table_name not in self.model_map:
+                    logger.error(f"Unsafe or unknown table name detected (count): {table_name}")
+                    raise Exception(f"Unsafe or unknown table name detected (count): {table_name}")
                 cursor.execute(f"SELECT COUNT(*) FROM {table_name};")
                 imported_count = cursor.fetchone()[0]
             


### PR DESCRIPTION
Potential fix for [https://github.com/eclipse-efbt/efbt/security/code-scanning/113](https://github.com/eclipse-efbt/efbt/security/code-scanning/113)

To fix this SQL injection vulnerability, you must validate the table name before interpolating it into any SQL query. This is best done by checking that the table name matches a strict regular expression allowing only safe characters (e.g., letters, numbers, underscores), and possibly by comparing it to the set of known table names from your ORM model map.

- **General approach:** Add a check just before any usage of `table_name` in a SQL context to ensure that it matches an allowed pattern, and is present in `self.model_map`. If it fails, reject the operation and raise an exception.
- **Detailed fix:** In the `_bulk_sqlite_import_with_index` method, immediately before executing any SQL queries using `table_name` (esp. line 716), add a block to verify the safety of `table_name`:
  - Use a compiled regular expression such as `^[A-Za-z0-9_]+$` for allowed table names.
  - Additionally, verify that `table_name` is in `self.model_map` (already checked before calling this method, but repeating here to be extra safe).
- **Region to change:** Add the validation at the start of `_bulk_sqlite_import_with_index`, and immediately before executing queries with `table_name` (esp. at line 716).
- **Needed:** Import `re` is already present, so just use it. Add a helper function if needed (`_is_safe_table_name`). You may optionally use the (already defined) `_is_safe_table_name` to encapsulate the regex test.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
