### PR TITLE
fix: add allow-modals to review page iframes for delete functionality

### DIFF
--- a/birds_nest/pybirdai/templates/pybirdai/miscellaneous/edit_cube_links_embed.html
+++ b/birds_nest/pybirdai/templates/pybirdai/miscellaneous/edit_cube_links_embed.html
@@ -377,7 +377,7 @@
             const container = document.getElementById('cube-links-container');
             container.classList.add('loading');
 
-            fetch(`/pybirdai/api/cube-links/list/?${params.toString()}`)
+            fetch(`/pybirdai/api/cube-links/list/?${params.toString()}&_t=${Date.now()}`)
                 .then(response => {
                     if (!response.ok) {
                         throw new Error(`HTTP ${response.status}: ${response.statusText}`);

--- a/birds_nest/pybirdai/templates/pybirdai/miscellaneous/edit_cube_links_embed.html
+++ b/birds_nest/pybirdai/templates/pybirdai/miscellaneous/edit_cube_links_embed.html
@@ -459,6 +459,11 @@
                 if (data.status === 'success') {
                     showMessage(data.message, 'success');
                     loadCubeLinks();
+                    // Notify parent to refresh other iframes (cascading delete affects structure/member links)
+                    window.parent.postMessage({
+                        type: 'cubelink-deleted',
+                        cubeLinkId: cubeLinkId
+                    }, '*');
                 } else {
                     showMessage('Error: ' + data.message, 'error');
                 }

--- a/birds_nest/pybirdai/templates/pybirdai/miscellaneous/edit_cube_structure_item_links_embed.html
+++ b/birds_nest/pybirdai/templates/pybirdai/miscellaneous/edit_cube_structure_item_links_embed.html
@@ -443,6 +443,11 @@
                 if (data.status === 'success') {
                     showMessage(data.message, 'success');
                     loadStructureItemLinks();
+                    // Notify parent to refresh member links iframe (cascading delete affects member links)
+                    window.parent.postMessage({
+                        type: 'structureitemlink-deleted',
+                        linkId: linkId
+                    }, '*');
                 } else {
                     showMessage('Error: ' + data.message, 'error');
                 }
@@ -628,6 +633,13 @@
                     showMessage('Unable to load filter options. They may be empty.', 'error');
                 });
         }
+
+        // Listen for refresh commands from parent (when cube link is deleted)
+        window.addEventListener('message', function(event) {
+            if (event.data && event.data.type === 'refresh-structure-item-links') {
+                loadStructureItemLinks();
+            }
+        });
 
         // Load structure item links on page load
         document.addEventListener('DOMContentLoaded', function() {

--- a/birds_nest/pybirdai/templates/pybirdai/miscellaneous/edit_cube_structure_item_links_embed.html
+++ b/birds_nest/pybirdai/templates/pybirdai/miscellaneous/edit_cube_structure_item_links_embed.html
@@ -435,7 +435,8 @@
                 method: 'POST',
                 headers: {
                     'X-CSRFToken': csrftoken,
-                    'Content-Type': 'application/json'
+                    'Content-Type': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest'
                 }
             })
             .then(response => response.json())

--- a/birds_nest/pybirdai/templates/pybirdai/miscellaneous/edit_cube_structure_item_links_embed.html
+++ b/birds_nest/pybirdai/templates/pybirdai/miscellaneous/edit_cube_structure_item_links_embed.html
@@ -363,7 +363,7 @@
             const container = document.getElementById('structure-item-links-container');
             container.classList.add('loading');
 
-            fetch(`/pybirdai/api/cube-structure-item-links/list/?${params.toString()}`)
+            fetch(`/pybirdai/api/cube-structure-item-links/list/?${params.toString()}&_t=${Date.now()}`)
                 .then(response => {
                     if (!response.ok) {
                         throw new Error(`HTTP ${response.status}: ${response.statusText}`);

--- a/birds_nest/pybirdai/templates/pybirdai/miscellaneous/member_links_embed.html
+++ b/birds_nest/pybirdai/templates/pybirdai/miscellaneous/member_links_embed.html
@@ -456,7 +456,7 @@
             const container = document.getElementById('member-links-container');
             container.classList.add('loading');
 
-            fetch(`/pybirdai/api/member-links/list/?${params.toString()}`)
+            fetch(`/pybirdai/api/member-links/list/?${params.toString()}&_t=${Date.now()}`)
                 .then(response => {
                     if (!response.ok) {
                         throw new Error(`HTTP ${response.status}: ${response.statusText}`);

--- a/birds_nest/pybirdai/templates/pybirdai/miscellaneous/member_links_embed.html
+++ b/birds_nest/pybirdai/templates/pybirdai/miscellaneous/member_links_embed.html
@@ -629,6 +629,13 @@
                 });
         }
 
+        // Listen for refresh commands from parent (when cube link or structure item link is deleted)
+        window.addEventListener('message', function(event) {
+            if (event.data && event.data.type === 'refresh-member-links') {
+                loadMemberLinks();
+            }
+        });
+
         // Load member links on page load
         document.addEventListener('DOMContentLoaded', function() {
             loadFilterOptions();

--- a/birds_nest/pybirdai/templates/pybirdai/workflow/ancrdt_workflow/step_2_review.html
+++ b/birds_nest/pybirdai/templates/pybirdai/workflow/ancrdt_workflow/step_2_review.html
@@ -211,7 +211,7 @@
         <div class="tab-content active" id="cube-links-tab-2">
             <iframe
                 src="{% url 'pybirdai:edit_cube_links_embed' %}"
-                sandbox="allow-scripts allow-same-origin allow-forms"
+                sandbox="allow-scripts allow-same-origin allow-forms allow-modals"
                 referrerpolicy="same-origin"
                 title="Edit Cube Links">
             </iframe>
@@ -220,7 +220,7 @@
         <div class="tab-content" id="structure-links-tab-2">
             <iframe
                 src="{% url 'pybirdai:edit_cube_structure_item_links_embed' %}"
-                sandbox="allow-scripts allow-same-origin allow-forms"
+                sandbox="allow-scripts allow-same-origin allow-forms allow-modals"
                 referrerpolicy="same-origin"
                 title="Edit Cube Structure Item Links">
             </iframe>
@@ -229,7 +229,7 @@
         <div class="tab-content" id="member-links-tab-2">
             <iframe
                 src="{% url 'pybirdai:edit_member_links_embed' %}"
-                sandbox="allow-scripts allow-same-origin allow-forms"
+                sandbox="allow-scripts allow-same-origin allow-forms allow-modals"
                 referrerpolicy="same-origin"
                 title="Edit Member Links">
             </iframe>

--- a/birds_nest/pybirdai/templates/pybirdai/workflow/ancrdt_workflow/step_2_review.html
+++ b/birds_nest/pybirdai/templates/pybirdai/workflow/ancrdt_workflow/step_2_review.html
@@ -210,6 +210,7 @@
         <!-- Tab Content -->
         <div class="tab-content active" id="cube-links-tab-2">
             <iframe
+                id="cube-links-iframe"
                 src="{% url 'pybirdai:edit_cube_links_embed' %}"
                 sandbox="allow-scripts allow-same-origin allow-forms allow-modals"
                 referrerpolicy="same-origin"
@@ -219,6 +220,7 @@
 
         <div class="tab-content" id="structure-links-tab-2">
             <iframe
+                id="structure-links-iframe"
                 src="{% url 'pybirdai:edit_cube_structure_item_links_embed' %}"
                 sandbox="allow-scripts allow-same-origin allow-forms allow-modals"
                 referrerpolicy="same-origin"
@@ -228,6 +230,7 @@
 
         <div class="tab-content" id="member-links-tab-2">
             <iframe
+                id="member-links-iframe"
                 src="{% url 'pybirdai:edit_member_links_embed' %}"
                 sandbox="allow-scripts allow-same-origin allow-forms allow-modals"
                 referrerpolicy="same-origin"
@@ -400,5 +403,28 @@ function exportVisualization() {
     a.click();
     document.body.removeChild(a);
 }
+
+// Listen for delete events from iframes to coordinate cross-iframe refresh
+window.addEventListener('message', function(event) {
+    if (!event.data || !event.data.type) return;
+
+    const structureLinksIframe = document.getElementById('structure-links-iframe');
+    const memberLinksIframe = document.getElementById('member-links-iframe');
+
+    if (event.data.type === 'cubelink-deleted') {
+        // Cube link deleted - refresh structure links and member links iframes
+        if (structureLinksIframe && structureLinksIframe.contentWindow) {
+            structureLinksIframe.contentWindow.postMessage({type: 'refresh-structure-item-links'}, '*');
+        }
+        if (memberLinksIframe && memberLinksIframe.contentWindow) {
+            memberLinksIframe.contentWindow.postMessage({type: 'refresh-member-links'}, '*');
+        }
+    } else if (event.data.type === 'structureitemlink-deleted') {
+        // Structure item link deleted - refresh member links iframe
+        if (memberLinksIframe && memberLinksIframe.contentWindow) {
+            memberLinksIframe.contentWindow.postMessage({type: 'refresh-member-links'}, '*');
+        }
+    }
+});
 </script>
 {% endblock %}

--- a/birds_nest/pybirdai/templates/pybirdai/workflow/ancrdt_workflow/step_3_review.html
+++ b/birds_nest/pybirdai/templates/pybirdai/workflow/ancrdt_workflow/step_3_review.html
@@ -125,7 +125,7 @@
         <!-- Unified Editor (filtered to show only ANCRDT files) -->
         <iframe
             src="{% url 'pybirdai:unified_filter_code_editor' %}?f={{ encoded_file_filter }}&default_file=smallest"
-            sandbox="allow-scripts allow-same-origin allow-forms"
+            sandbox="allow-scripts allow-same-origin allow-forms allow-modals"
             referrerpolicy="same-origin"
             title="Filter Code Editor"
             style="width: 100%; min-height: 800px; border: none; display: block;">

--- a/birds_nest/pybirdai/templates/pybirdai/workflow/dpm_workflow/dpm_review.html
+++ b/birds_nest/pybirdai/templates/pybirdai/workflow/dpm_workflow/dpm_review.html
@@ -148,6 +148,7 @@
         <!-- Tab Content -->
         <div class="tab-content active" id="cube-links-tab-4">
             <iframe
+                id="cube-links-iframe"
                 src="{% url 'pybirdai:edit_cube_links_embed' %}"
                 sandbox="allow-scripts allow-same-origin allow-forms allow-modals"
                 referrerpolicy="same-origin"
@@ -157,6 +158,7 @@
 
         <div class="tab-content" id="structure-links-tab-4">
             <iframe
+                id="structure-links-iframe"
                 src="{% url 'pybirdai:edit_cube_structure_item_links_embed' %}"
                 sandbox="allow-scripts allow-same-origin allow-forms allow-modals"
                 referrerpolicy="same-origin"
@@ -166,6 +168,7 @@
 
         <div class="tab-content" id="member-links-tab-4">
             <iframe
+                id="member-links-iframe"
                 src="{% url 'pybirdai:edit_member_links_embed' %}"
                 sandbox="allow-scripts allow-same-origin allow-forms allow-modals"
                 referrerpolicy="same-origin"
@@ -1441,6 +1444,29 @@ function executeDPMStep(stepNumber) {
         // The actual execution will be triggered from the dashboard
     }
 }
+
+// Listen for delete events from iframes to coordinate cross-iframe refresh (for Step 4)
+window.addEventListener('message', function(event) {
+    if (!event.data || !event.data.type) return;
+
+    const structureLinksIframe = document.getElementById('structure-links-iframe');
+    const memberLinksIframe = document.getElementById('member-links-iframe');
+
+    if (event.data.type === 'cubelink-deleted') {
+        // Cube link deleted - refresh structure links and member links iframes
+        if (structureLinksIframe && structureLinksIframe.contentWindow) {
+            structureLinksIframe.contentWindow.postMessage({type: 'refresh-structure-item-links'}, '*');
+        }
+        if (memberLinksIframe && memberLinksIframe.contentWindow) {
+            memberLinksIframe.contentWindow.postMessage({type: 'refresh-member-links'}, '*');
+        }
+    } else if (event.data.type === 'structureitemlink-deleted') {
+        // Structure item link deleted - refresh member links iframe
+        if (memberLinksIframe && memberLinksIframe.contentWindow) {
+            memberLinksIframe.contentWindow.postMessage({type: 'refresh-member-links'}, '*');
+        }
+    }
+});
 
 // Cube Structure Viewer JavaScript (only for step 3)
 {% if step_number == 3 %}

--- a/birds_nest/pybirdai/templates/pybirdai/workflow/dpm_workflow/dpm_review.html
+++ b/birds_nest/pybirdai/templates/pybirdai/workflow/dpm_workflow/dpm_review.html
@@ -149,7 +149,7 @@
         <div class="tab-content active" id="cube-links-tab-4">
             <iframe
                 src="{% url 'pybirdai:edit_cube_links_embed' %}"
-                sandbox="allow-scripts allow-same-origin allow-forms"
+                sandbox="allow-scripts allow-same-origin allow-forms allow-modals"
                 referrerpolicy="same-origin"
                 title="Edit Cube Links">
             </iframe>
@@ -158,7 +158,7 @@
         <div class="tab-content" id="structure-links-tab-4">
             <iframe
                 src="{% url 'pybirdai:edit_cube_structure_item_links_embed' %}"
-                sandbox="allow-scripts allow-same-origin allow-forms"
+                sandbox="allow-scripts allow-same-origin allow-forms allow-modals"
                 referrerpolicy="same-origin"
                 title="Edit Cube Structure Item Links">
             </iframe>
@@ -167,7 +167,7 @@
         <div class="tab-content" id="member-links-tab-4">
             <iframe
                 src="{% url 'pybirdai:edit_member_links_embed' %}"
-                sandbox="allow-scripts allow-same-origin allow-forms"
+                sandbox="allow-scripts allow-same-origin allow-forms allow-modals"
                 referrerpolicy="same-origin"
                 title="Edit Member Links">
             </iframe>
@@ -197,7 +197,7 @@
         <div class="tab-content active" id="filters-tab-5">
             <iframe
                 src="{% url 'pybirdai:unified_filter_code_editor' %}?f={{ encoded_filter_files }}&default_file=smallest"
-                sandbox="allow-scripts allow-same-origin allow-forms"
+                sandbox="allow-scripts allow-same-origin allow-forms allow-modals"
                 referrerpolicy="same-origin"
                 title="Filter Code Editor">
             </iframe>
@@ -206,7 +206,7 @@
         <div class="tab-content" id="joins-tab-5">
             <iframe
                 src="{% url 'pybirdai:unified_filter_code_editor' %}?f={{ encoded_join_files }}&default_file=smallest"
-                sandbox="allow-scripts allow-same-origin allow-forms"
+                sandbox="allow-scripts allow-same-origin allow-forms allow-modals"
                 referrerpolicy="same-origin"
                 title="Join Code Editor (Note: This uses filter code editor - join editor to be implemented)">
             </iframe>

--- a/birds_nest/pybirdai/templates/pybirdai/workflow/main_workflow/task2/review.html
+++ b/birds_nest/pybirdai/templates/pybirdai/workflow/main_workflow/task2/review.html
@@ -119,6 +119,7 @@
         <!-- Tab Content -->
         <div class="tab-content active" id="cube-links-tab-2">
             <iframe
+                id="cube-links-iframe"
                 src="{% url 'pybirdai:edit_cube_links_embed' %}"
                 sandbox="allow-scripts allow-same-origin allow-forms allow-modals"
                 referrerpolicy="same-origin"
@@ -128,6 +129,7 @@
 
         <div class="tab-content" id="structure-links-tab-2">
             <iframe
+                id="structure-links-iframe"
                 src="{% url 'pybirdai:edit_cube_structure_item_links_embed' %}"
                 sandbox="allow-scripts allow-same-origin allow-forms allow-modals"
                 referrerpolicy="same-origin"
@@ -137,6 +139,7 @@
 
         <div class="tab-content" id="member-links-tab-2">
             <iframe
+                id="member-links-iframe"
                 src="{% url 'pybirdai:edit_member_links_embed' %}"
                 sandbox="allow-scripts allow-same-origin allow-forms allow-modals"
                 referrerpolicy="same-origin"
@@ -965,5 +968,28 @@ function exportVisualization() {
     a.click();
     document.body.removeChild(a);
 }
+
+// Listen for delete events from iframes to coordinate cross-iframe refresh
+window.addEventListener('message', function(event) {
+    if (!event.data || !event.data.type) return;
+
+    const structureLinksIframe = document.getElementById('structure-links-iframe');
+    const memberLinksIframe = document.getElementById('member-links-iframe');
+
+    if (event.data.type === 'cubelink-deleted') {
+        // Cube link deleted - refresh structure links and member links iframes
+        if (structureLinksIframe && structureLinksIframe.contentWindow) {
+            structureLinksIframe.contentWindow.postMessage({type: 'refresh-structure-item-links'}, '*');
+        }
+        if (memberLinksIframe && memberLinksIframe.contentWindow) {
+            memberLinksIframe.contentWindow.postMessage({type: 'refresh-member-links'}, '*');
+        }
+    } else if (event.data.type === 'structureitemlink-deleted') {
+        // Structure item link deleted - refresh member links iframe
+        if (memberLinksIframe && memberLinksIframe.contentWindow) {
+            memberLinksIframe.contentWindow.postMessage({type: 'refresh-member-links'}, '*');
+        }
+    }
+});
 </script>
 {% endblock %}

--- a/birds_nest/pybirdai/templates/pybirdai/workflow/main_workflow/task3/review.html
+++ b/birds_nest/pybirdai/templates/pybirdai/workflow/main_workflow/task3/review.html
@@ -35,7 +35,7 @@
         <!-- Unified Code Editor (filtered to show only FINREP files) -->
         <iframe
             src="{% url 'pybirdai:unified_filter_code_editor' %}?f={{ encoded_file_filter }}&default_file=smallest"
-            sandbox="allow-scripts allow-same-origin allow-forms"
+            sandbox="allow-scripts allow-same-origin allow-forms allow-modals"
             referrerpolicy="same-origin"
             title="Filter Code Editor"
             style="width: 100%; min-height: 800px; border: none; display: block;">

--- a/birds_nest/pybirdai/views/core/cube_link_views.py
+++ b/birds_nest/pybirdai/views/core/cube_link_views.py
@@ -170,6 +170,12 @@ def delete_cube_structure_item_link(request, cube_structure_item_link_id, from_d
         cube_structure_item_link_id: ID of the link to delete
         from_duplicate_list: If True, redirect to duplicate list with preserved filters
     """
+    # Check if this is an AJAX request (from embed iframe)
+    is_ajax = (
+        request.headers.get('X-Requested-With') == 'XMLHttpRequest' or
+        request.content_type == 'application/json'
+    )
+
     try:
         link = get_object_or_404(CUBE_STRUCTURE_ITEM_LINK, cube_structure_item_link_id=cube_structure_item_link_id)
         # Store the cube_link_id before deleting
@@ -187,11 +193,19 @@ def delete_cube_structure_item_link(request, cube_structure_item_link_id, from_d
         remove_cube_structure_item_link_from_cache(cube_structure_item_link_id, cube_link_id)
 
         if member_links_deleted > 0:
-            messages.success(request, f'Link deleted successfully (also deleted {member_links_deleted} member link(s)).')
+            message = f'Link deleted successfully (also deleted {member_links_deleted} member link(s)).'
         else:
-            messages.success(request, 'Link deleted successfully.')
+            message = 'Link deleted successfully.'
+
+        # Return JSON for AJAX requests, redirect for regular form submissions
+        if is_ajax:
+            return JsonResponse({'status': 'success', 'message': message})
+
+        messages.success(request, message)
     except Exception as e:
         from pybirdai.utils.secure_error_handling import SecureErrorHandler
+        if is_ajax:
+            return JsonResponse({'status': 'error', 'message': str(e)}, status=400)
         SecureErrorHandler.secure_message(request, e, 'cube structure item link deletion')
 
     # Check the referer to determine which page to redirect back to

--- a/birds_nest/pybirdai/views/core/cube_link_views.py
+++ b/birds_nest/pybirdai/views/core/cube_link_views.py
@@ -23,7 +23,7 @@ from django.views.decorators.http import require_http_methods
 from django.views.decorators.clickjacking import xframe_options_exempt
 
 from pybirdai.models.bird_meta_data_model import (
-    CUBE_LINK, CUBE_STRUCTURE_ITEM_LINK, CUBE, CUBE_STRUCTURE_ITEM
+    CUBE_LINK, CUBE_STRUCTURE_ITEM_LINK, CUBE, CUBE_STRUCTURE_ITEM, MEMBER_LINK
 )
 from .cache_manager import (
     remove_cube_link_from_cache,
@@ -122,17 +122,38 @@ def edit_cube_structure_item_links(request):
 
 
 def delete_cube_link(request, cube_link_id):
-    """Delete cube link with cache updates."""
+    """Delete cube link with cascading deletion of child records and cache updates."""
     try:
         link = get_object_or_404(CUBE_LINK, cube_link_id=cube_link_id)
 
-        # Update the in-memory dictionaries
+        # Find all child CUBE_STRUCTURE_ITEM_LINKs
+        child_links = CUBE_STRUCTURE_ITEM_LINK.objects.filter(cube_link_id=cube_link_id)
+        child_link_ids = list(child_links.values_list('cube_structure_item_link_id', flat=True))
+
+        # Delete all grandchild MEMBER_LINKs for each child
+        member_links_deleted = 0
+        for child_link_id in child_link_ids:
+            deleted_count, _ = MEMBER_LINK.objects.filter(
+                cube_structure_item_link_id=child_link_id
+            ).delete()
+            member_links_deleted += deleted_count
+
+        # Update cache for each child CUBE_STRUCTURE_ITEM_LINK before deletion
+        for child_link_id in child_link_ids:
+            remove_cube_structure_item_link_from_cache(child_link_id, cube_link_id)
+
+        # Delete all child CUBE_STRUCTURE_ITEM_LINKs
+        structure_links_deleted, _ = child_links.delete()
+
+        # Update the in-memory dictionaries for parent
         remove_cube_link_from_cache(cube_link_id)
 
-        # Delete the database record
+        # Delete the parent CUBE_LINK
         link.delete()
-        messages.success(request, 'CUBE_LINK deleted successfully.')
-        return JsonResponse({'status': 'success'})
+
+        message = f'CUBE_LINK deleted successfully (also deleted {structure_links_deleted} structure item link(s) and {member_links_deleted} member link(s)).'
+        messages.success(request, message)
+        return JsonResponse({'status': 'success', 'message': message})
     except Exception as e:
         from pybirdai.utils.secure_error_handling import SecureErrorHandler
         SecureErrorHandler.secure_message(request, e, "CUBE_LINK deletion")
@@ -142,7 +163,7 @@ def delete_cube_link(request, cube_link_id):
 @require_http_methods(["POST"])
 def delete_cube_structure_item_link(request, cube_structure_item_link_id, from_duplicate_list=False):
     """
-    Delete cube structure item link with cache updates.
+    Delete cube structure item link with cascading deletion of member links and cache updates.
 
     Args:
         request: HTTP request
@@ -153,12 +174,22 @@ def delete_cube_structure_item_link(request, cube_structure_item_link_id, from_d
         link = get_object_or_404(CUBE_STRUCTURE_ITEM_LINK, cube_structure_item_link_id=cube_structure_item_link_id)
         # Store the cube_link_id before deleting
         cube_link_id = link.cube_link_id.cube_link_id if link.cube_link_id else None
+
+        # Delete all child MEMBER_LINKs first
+        member_links_deleted, _ = MEMBER_LINK.objects.filter(
+            cube_structure_item_link_id=cube_structure_item_link_id
+        ).delete()
+
+        # Delete the CUBE_STRUCTURE_ITEM_LINK
         link.delete()
 
         # Update the in-memory dictionaries
         remove_cube_structure_item_link_from_cache(cube_structure_item_link_id, cube_link_id)
 
-        messages.success(request, 'Link deleted successfully.')
+        if member_links_deleted > 0:
+            messages.success(request, f'Link deleted successfully (also deleted {member_links_deleted} member link(s)).')
+        else:
+            messages.success(request, 'Link deleted successfully.')
     except Exception as e:
         from pybirdai.utils.secure_error_handling import SecureErrorHandler
         SecureErrorHandler.secure_message(request, e, 'cube structure item link deletion')
@@ -186,7 +217,7 @@ def delete_cube_structure_item_link_dupl(request, cube_structure_item_link_id):
 
 @require_http_methods(["POST"])
 def bulk_delete_cube_structure_item_links(request):
-    """Bulk deletion with in-memory cache updates."""
+    """Bulk deletion with cascading deletion of member links and in-memory cache updates."""
     logger.info("Received request to bulk delete CUBE_STRUCTURE_ITEM_LINK items.")
 
     selected_ids = request.POST.getlist('selected_items')
@@ -212,6 +243,13 @@ def bulk_delete_cube_structure_item_links(request):
             for link in links_to_delete
         ]
 
+        # Delete all child MEMBER_LINKs first (cascading delete)
+        logger.info("Deleting child MEMBER_LINK records first (cascading delete).")
+        member_links_deleted, _ = MEMBER_LINK.objects.filter(
+            cube_structure_item_link_id__in=selected_ids
+        ).delete()
+        logger.info(f"Deleted {member_links_deleted} child MEMBER_LINK record(s).")
+
         logger.info("Starting bulk deletion of CUBE_STRUCTURE_ITEM_LINK objects from database.")
         deleted_count, _ = links_to_delete.delete()
         logger.info(f"Database deletion complete. Deleted {deleted_count} link(s).")
@@ -221,8 +259,11 @@ def bulk_delete_cube_structure_item_links(request):
         for cube_structure_item_link_id, cube_link_id in link_info:
             remove_cube_structure_item_link_from_cache(cube_structure_item_link_id, cube_link_id)
 
-        messages.success(request, f"{deleted_count} link(s) deleted successfully.")
-        logger.info(f"Bulk deletion process completed successfully. {deleted_count} link(s) deleted.")
+        if member_links_deleted > 0:
+            messages.success(request, f"{deleted_count} link(s) deleted successfully (also deleted {member_links_deleted} member link(s)).")
+        else:
+            messages.success(request, f"{deleted_count} link(s) deleted successfully.")
+        logger.info(f"Bulk deletion process completed successfully. {deleted_count} link(s) and {member_links_deleted} member link(s) deleted.")
     except Exception as e:
         logger.error(f'Error during bulk deletion: {str(e)}', exc_info=True)
         from pybirdai.utils.secure_error_handling import SecureErrorHandler

--- a/birds_nest/pybirdai/views/joins_metadata_embed_views.py
+++ b/birds_nest/pybirdai/views/joins_metadata_embed_views.py
@@ -63,11 +63,16 @@ def api_cube_links_list(request):
             'order_relevance': link.order_relevance,
         })
 
-    return JsonResponse({
+    response = JsonResponse({
         'status': 'success',
         'links': links,
         'count': len(links)
     })
+    # Prevent browser caching to ensure fresh data after deletions
+    response['Cache-Control'] = 'no-cache, no-store, must-revalidate'
+    response['Pragma'] = 'no-cache'
+    response['Expires'] = '0'
+    return response
 
 
 def api_cube_links_filter_options(request):
@@ -121,11 +126,16 @@ def api_cube_structure_item_links_list(request):
             'primary_cube_id': link.cube_link_id.primary_cube_id.cube_id if link.cube_link_id and link.cube_link_id.primary_cube_id else None,
         })
 
-    return JsonResponse({
+    response = JsonResponse({
         'status': 'success',
         'links': links,
         'count': len(links)
     })
+    # Prevent browser caching to ensure fresh data after deletions
+    response['Cache-Control'] = 'no-cache, no-store, must-revalidate'
+    response['Pragma'] = 'no-cache'
+    response['Expires'] = '0'
+    return response
 
 
 def api_cube_structure_item_links_filter_options(request):

--- a/birds_nest/pybirdai/views/member_link_views.py
+++ b/birds_nest/pybirdai/views/member_link_views.py
@@ -165,11 +165,16 @@ def get_member_links_json(request):
                 'valid_to': link.valid_to.isoformat() if link.valid_to else None,
             })
 
-        return JsonResponse({
+        response = JsonResponse({
             'status': 'success',
             'links': links,
             'count': len(links)
         })
+        # Prevent browser caching to ensure fresh data after deletions
+        response['Cache-Control'] = 'no-cache, no-store, must-revalidate'
+        response['Pragma'] = 'no-cache'
+        response['Expires'] = '0'
+        return response
     except Exception as e:
         return JsonResponse({
             'status': 'error',


### PR DESCRIPTION
The delete buttons for cube_links, cube_structure_item_links, and member_links use confirm() dialogs which require the allow-modals sandbox attribute. This was fixed for FINREP task2/review but not for other review pages.

Fixed templates:
- ancrdt_workflow/step_2_review.html (3 iframes)
- ancrdt_workflow/step_3_review.html (1 iframe)
- dpm_workflow/dpm_review.html (5 iframes)
- main_workflow/task3/review.html (1 iframe)